### PR TITLE
Fixing up Typesafe repo location

### DIFF
--- a/src/main/g8/sbt
+++ b/src/main/g8/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="\$2"
   version="\$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-\$category/\$groupid/sbt-launch/\$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-\$category/\$groupid/sbt-launch/\$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"


### PR DESCRIPTION
The Typesafe repo URL has changed, this should fix it.

Notice is here: https://www.typesafe.com/blog/incident-report-for-repo-typesafe-com-and-repo-scala-sbt-org