### PR TITLE
Final fix for bad bundled SBT launcher

### DIFF
--- a/src/main/g8/sbt
+++ b/src/main/g8/sbt
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p \$(dirname "\$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "\$url" --output "\$jar"
+      curl -L --fail --silent "\$url" --output "\$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "\$jar" "\$url"
     fi


### PR DESCRIPTION
The sbt-launcher.jar location move was still biting us - this PR adds the -L flag to Curl so that it follows redirects and gets the actual jar file rather than an HTML file indicating a redirect. 

Wget works alright. 