### PR TITLE
fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: scala
 
 sudo: false
 
+jdk: oraclejdk8
+
 scala:
-  - 2.10.6
   - 2.11.8
+  # TODO 2.12.0 https://github.com/scalatra/scalatra-sbt.g8/issues/57
 
 script:
   - sbt ";set g8Properties in g8 in Test ~= { _ + (\"scala_version\" -> \"$TRAVIS_SCALA_VERSION\")}; g8Test"


### PR DESCRIPTION
- scalatra 2.5.x dropped Scala 2.10 support
- scalatra 2.5.x dropped Java 7 support
- add TODO comment