### PR TITLE
Replace xsbt-scalate-generator to support Scala 2.12

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,13 +1,13 @@
 import org.scalatra.sbt._
 import org.scalatra.sbt.PluginKeys._
-import com.mojolly.scalate.ScalatePlugin._
+import ScalateKeys._
 import ScalateKeys._
 
 val ScalatraVersion = "$scalatra_version$"
 
 ScalatraPlugin.scalatraSettings
 
-scalateSettings
+seq(scalateSettings:_*)
 
 organization := "$organization$"
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,13 +1,12 @@
 import org.scalatra.sbt._
 import org.scalatra.sbt.PluginKeys._
 import ScalateKeys._
-import ScalateKeys._
 
 val ScalatraVersion = "$scalatra_version$"
 
 ScalatraPlugin.scalatraSettings
 
-seq(scalateSettings:_*)
+scalateSettings
 
 organization := "$organization$"
 

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,6 +3,6 @@ name=My Scalatra Web App
 version=0.1.0-SNAPSHOT
 servlet_name=MyScalatraServlet
 package=com.example.app
-scala_version=2.11.8
+scala_version=2.12.1
 sbt_version=0.13.13
 scalatra_version=maven(org.scalatra, scalatra_2.11)

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.skinny-framework" % "sbt-scalate-precompiler" % "1.8.0.0")
+addSbtPlugin("org.scalatra.scalate" % "sbt-scalate-precompiler" % "1.8.0.1")
 
 addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.5.1")

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.mojolly.scalate" % "xsbt-scalate-generator" % "0.5.0")
+addSbtPlugin("org.skinny-framework" % "sbt-scalate-precompiler" % "1.8.0.0")
 
 addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.5.1")


### PR DESCRIPTION
Scala 2.12 version of [xsbt-scalate-generator](https://github.com/backchatio/xsbt-scalate-generate) has not been released yet but [This fork](https://github.com/skinny-framework/sbt-scalate-precompiler) is active and already supports Scala 2.12. If it's impossible to continue to maintain xsbt-scalate-generator, I guess moving to this fork is better solution.

See also #57.