### PR TITLE
use ScalatraPlugin

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -19,4 +19,4 @@ libraryDependencies ++= Seq(
 )
 
 enablePlugins(SbtTwirl)
-enablePlugins(JettyPlugin)
+enablePlugins(ScalatraPlugin)


### PR DESCRIPTION
JettyPlugin is enabled by ScalatraPlugin. Since sbt-scalatra is explicitly
specified in plugin.sbt, it is easier to understand.